### PR TITLE
feat: set ecma version to 8 (2017)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 module.exports = {
   parserOptions: {
-    ecmaVersion: 6,
+    ecmaVersion: 8,
   },
   env: {
     es6: true,


### PR DESCRIPTION
We want support for async/await without transpilation, specially in tooling repos