### PR TITLE
fix: formatting of eslintrc output

### DIFF
--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ ! -f "${INIT_CWD}/.eslintrc.json" ]; then
-  echo '{\n "extends": ["@weahead/eslint-config-tool"] \n}' > "${INIT_CWD}/.eslintrc.json"
+  echo '{\n  "extends": ["@weahead/eslint-config-tool"]\n}' >"${INIT_CWD}/.eslintrc.json"
 fi


### PR DESCRIPTION
The output of `.eslintrc.json` is not "prettierified". This PR fixes that.